### PR TITLE
AN-109087: Fix non-exact Date encoding

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -53,11 +53,11 @@ func writeData(dbuf *bytes.Buffer, order binary.ByteOrder, data *K) error {
 		}
 	case -KD: // Date
 		date := data.Data.(time.Time)
-		days := date.Sub(qEpoch) / (time.Hour * 24)
+		days := date.Truncate(time.Hour * 24).Sub(qEpoch) / (time.Hour * 24)
 		binary.Write(dbuf, order, int32(days))
 	case KD: // Date
 		for _, date := range data.Data.([]time.Time) {
-			days := date.Sub(qEpoch) / (time.Hour * 24)
+			days := date.Truncate(time.Hour * 24).Sub(qEpoch) / (time.Hour * 24)
 			binary.Write(dbuf, order, int32(days))
 		}
 	case -KT: // Time

--- a/encode_test.go
+++ b/encode_test.go
@@ -148,3 +148,25 @@ func TestEncoding(t *testing.T) {
 		}
 	}
 }
+
+func TestEncoding_Date_NotExact(t *testing.T) {
+	before1970Desc := "1969-12-31 23:59:50 +0000 UTC" // In kdb this is equivalent to `1969.12.31`
+	before1970Input := Date(time.Date(1969, 12, 31, 23, 59, 50, 0, time.UTC))
+	before1970Bytes := []byte{0x01, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0xf2, 0x32, 0xd5, 0xff, 0xff}
+	beforeBuf := new(bytes.Buffer)
+	if err := Encode(beforeBuf, ASYNC, before1970Input); err != nil {
+		t.Errorf("Encoding '%s' failed:%s", before1970Desc, err)
+	} else if !bytes.Equal(beforeBuf.Bytes(), before1970Bytes) {
+		t.Errorf("Encoded '%s' incorrectly. Expected '%v', got '%v'\n", before1970Desc, before1970Bytes, beforeBuf.Bytes())
+	}
+
+	after1970Desc := "1970-01-01 00:00:10 +0000 UTC" // In kdb this is equivalent to `1970.01.01`
+	after1970Input := Date(time.Date(1970, 1, 1, 0, 0, 10, 0, time.UTC))
+	after1970Bytes := []byte{0x01, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0xf2, 0x33, 0xd5, 0xff, 0xff}
+	afterBuf := new(bytes.Buffer)
+	if err := Encode(afterBuf, ASYNC, after1970Input); err != nil {
+		t.Errorf("Encoding '%s' failed:%s", after1970Desc, err)
+	} else if !bytes.Equal(afterBuf.Bytes(), after1970Bytes) {
+		t.Errorf("Encoded '%s' incorrectly. Expected '%v', got '%v'\n", after1970Desc, after1970Bytes, afterBuf.Bytes())
+	}
+}


### PR DESCRIPTION
[JIRA](https://issues.appian.com/browse/AN-109087)

CI: No automated CI for this repository

```
❯ go test --short -v --run TestEncoding
Starting q process on random port
Listening port is  60649
=== RUN   TestEncoding
--- PASS: TestEncoding (0.00s)
=== RUN   TestEncoding_Date_NotExact
--- PASS: TestEncoding_Date_NotExact (0.00s)
PASS
Q stdout output: "show `exiting_process;\n"

Q stdout output: `exiting_process

Q stdout output: "exit 0\n"

Q stdout output:
Q stdout error: EOF
ok  	_/Users/nima.yahyazadeh/repo/kdbgo	0.037s
```
